### PR TITLE
Fix typo in OpenPleb description

### DIFF
--- a/packages/landing/src/routes/+page.svelte
+++ b/packages/landing/src/routes/+page.svelte
@@ -133,7 +133,7 @@
 <section class="py-20 text-center bg-gradient-to-br from-gray-50 to-gray-100">
     <div class="max-w-3xl mx-auto px-4">
         <h2 class="text-3xl font-bold mb-4">Join the OpenPleb Project</h2>
-        <p class="text-lg text-gray-600 mb-6">OpenPlen is an open-source initiative. Developers, Designers, and Bitcoiners are welcome to contribute!</p>
+        <p class="text-lg text-gray-600 mb-6">OpenPleb is an open-source initiative. Developers, Designers, and Bitcoiners are welcome to contribute!</p>
         <a href="https://github.com/gandlafbtc/open-pleb" target="_blank" class="bg-orange-500 hover:bg-orange-600 text-white px-6 py-3 rounded-xl font-medium transition">View on Github</a>
     </div>
 </section>


### PR DESCRIPTION
Same typo still appears in website after previous merge, perhaps this is not the location to properly change it for good?